### PR TITLE
Revise output format to match given testcases

### DIFF
--- a/MP1.py
+++ b/MP1.py
@@ -126,22 +126,31 @@ def solve(algorithm: Algorithm, processes: List[Process], Z: int):
 
 
 def format_result(time_slices: List[tuple], Y: int):
-    total_waiting_time_by_pid = {}
+    process_time_slices = {}
     formatted = []
+
+    # Group time slices by process ID
     for time_slice in time_slices:
-        pid = time_slice[0]
-        waiting_time = time_slice[3]
+        pid, start_time, end_time, waiting_time = time_slice
+        if pid not in process_time_slices:
+            process_time_slices[pid] = {"time_slices": [], "total_waiting_time": 0}
 
-        if pid not in total_waiting_time_by_pid:
-            total_waiting_time_by_pid[pid] = 0
-
-        total_waiting_time_by_pid[pid] += waiting_time
-
-        formatted.append(
-            f"{pid} start time: {time_slice[1]} end time: {time_slice[2]} | Waiting time: {waiting_time}"
+        process_time_slices[pid]["time_slices"].append(
+            f"start time: {start_time} end time: {end_time}"
         )
+        process_time_slices[pid]["total_waiting_time"] += waiting_time
 
-    avg_waiting_time = sum(total_waiting_time_by_pid.values()) / Y
+    # Format output for each process
+    for pid in sorted(process_time_slices.keys()):
+        slices_str = " | ".join(process_time_slices[pid]["time_slices"])
+        waiting_time = process_time_slices[pid]["total_waiting_time"]
+        formatted.append(f"{pid} {slices_str} | Waiting time: {waiting_time}")
+
+    # Calculate average waiting time
+    total_waiting_time = sum(
+        value["total_waiting_time"] for value in process_time_slices.values()
+    )
+    avg_waiting_time = total_waiting_time / Y
     formatted.append(f"Average waiting time: {round(avg_waiting_time, 1)}")
 
     return "\n".join(formatted)


### PR DESCRIPTION
Revises the output such that from this Gantt-chart like format:
```
1 start time: 6 end time: 16 | Waiting time: 0
2 start time: 16 end time: 26 | Waiting time: 6
3 start time: 26 end time: 36 | Waiting time: 13
1 start time: 36 end time: 46 | Waiting time: 20
4 start time: 46 end time: 56 | Waiting time: 26
5 start time: 56 end time: 60 | Waiting time: 33
2 start time: 60 end time: 70 | Waiting time: 34
3 start time: 70 end time: 80 | Waiting time: 34
1 start time: 80 end time: 87 | Waiting time: 34
4 start time: 87 end time: 96 | Waiting time: 31
2 start time: 96 end time: 98 | Waiting time: 26
Average waiting time: 51.4
```
It now outputs it one line per process instead (i.e., with start/end times for a process grouped together):
```
1 start time: 6 end time: 16 | start time: 36 end time: 46 | start time: 80 end time: 87 | Waiting time: 54
2 start time: 16 end time: 26 | start time: 60 end time: 70 | start time: 96 end time: 98 | Waiting time: 66
3 start time: 26 end time: 36 | start time: 70 end time: 80 | Waiting time: 47
4 start time: 46 end time: 56 | start time: 87 end time: 96 | Waiting time: 57
5 start time: 56 end time: 60 | Waiting time: 33
Average waiting time: 51.4
```
The latter is the expected format as shown in the given testcases.